### PR TITLE
 增加一些域名和IP,以解决Steam下载无法使用国内CDN下载的问题

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,35 @@ jobs:
         run: |
           grep '@cn$' ./publish/category-games.txt | sed -e 's/^full:/DOMAIN,/' -e 's/^domain:/DOMAIN-SUFFIX,/' -e 's/^keyword:/DOMAIN-KEYWORD,/' -e 's/^regexp:/DOMAIN-REGEX,/' -e 's/:@cn$//' > ./tmp/temp-games-cn.txt
           curl -sSL ${games_cn1} | grep -Ev '#|IP-' >> ./tmp/temp-games-cn.txt
-          curl -sSL ${games_cn2} | grep -Ev '#|IP-' >> ./tmp/temp-games-cn.txt
+          curl -sSL ${games_cn2} | grep -Ev '#|IP-' >> ./tmp/temp-games-cn.txt          
+          # 增加下列域名和IP,以解决Steam下载无法使用国内CDN下载的问题
+          cat << EOF >> ./tmp/temp-games-cn.txt
+          *.cm.steampowered.com
+          *.steamserver.net
+          45.121.184.0/24
+          103.10.124.0/23
+          103.28.54.0/24
+          146.66.152.0/24
+          146.66.155.0/24
+          153.254.86.0/24
+          155.133.224.0/22
+          155.133.230.0/24
+          155.133.232.0/23
+          155.133.234.0/24
+          155.133.236.0/22
+          155.133.240.0/23
+          155.133.244.0/23
+          155.133.246.0/24
+          155.133.248.0/21
+          162.254.192.0/21
+          185.25.182.0/23
+          190.217.32.0/22
+          192.69.96.0/22
+          205.196.6.0/24
+          208.64.200.0/22
+          208.78.164.0/22
+          205.185.194.0/24
+          EOF
           sort --ignore-case -u ./tmp/temp-games-cn.txt > ./domains/games-cn.list
 
       - name: Generate netflix


### PR DESCRIPTION
cat << EOF >> ./tmp/temp-games-cn.txt
    *.cm.steampowered.com
    *.steamserver.net
    45.121.184.0/24
    103.10.124.0/23
    103.28.54.0/24
    146.66.152.0/24
    146.66.155.0/24
    153.254.86.0/24
    155.133.224.0/22
    155.133.230.0/24
    155.133.232.0/23
    155.133.234.0/24
    155.133.236.0/22
    155.133.240.0/23
    155.133.244.0/23
    155.133.246.0/24
    155.133.248.0/21
    162.254.192.0/21
    185.25.182.0/23
    190.217.32.0/22
    192.69.96.0/22
    205.196.6.0/24
    208.64.200.0/22
    208.78.164.0/22
    205.185.194.0/24
    EOF